### PR TITLE
Decouple vector store and encoders, also implementing openai ada support

### DIFF
--- a/benchmark-tests/README.md
+++ b/benchmark-tests/README.md
@@ -1,0 +1,1 @@
+This subdirectory is meant for random benchmarking experiments on memas internal components.

--- a/benchmark-tests/compare_encoders.py
+++ b/benchmark-tests/compare_encoders.py
@@ -1,0 +1,86 @@
+import datasets
+from datetime import datetime
+from memas.interface.encoder import TextEncoder
+from memas.encoder import openai_ada_encoder, universal_sentence_encoder
+from memas.text_parsing import text_parsers
+
+
+def prep_dataset():
+    wikipedia = datasets.load_dataset("wikipedia", "20220301.en")
+    test_sentences = []
+    i = 0
+    
+    start = datetime.now()
+    for row in wikipedia["train"]:
+        test_sentences.extend(text_parsers.split_doc(row["text"], 1024))
+        i += 1
+        if i > 10:
+            break
+    end = datetime.now()
+    print(f"Splitting {i} documents into {len(test_sentences)} sentences took {(end - start).total_seconds()}s")
+
+    batch_sentences = {}
+    for batch_size in [5, 10, 20, 50, 100]:
+        batched_list = [test_sentences[i:i+batch_size] for i in range(0, len(test_sentences), batch_size)]
+        # pop the last one since likely not fully populated
+        batched_list.pop()
+        batch_sentences[batch_size] = batched_list
+
+    return test_sentences, batch_sentences
+
+
+def benchmark_single(test_sentences: list[str], encoder: TextEncoder):
+    start = datetime.now()
+    i = 0
+    for sentence in test_sentences:
+        i += 1
+        try:
+            encoder.embed(sentence)
+        except Exception as err:
+            print(err)
+            print(f"{i}!", sentence)
+
+    end = datetime.now()
+    return (end - start).total_seconds()
+
+
+def benchmark_batch(batched_list: list[list[str]], encoder: TextEncoder):
+    start = datetime.now()
+    i = 0
+    for batch in batched_list:
+        i += 1
+        try:
+            encoder.embed_multiple(batch)
+        except Exception as err:
+            print(err)
+            print(f"{i}!", batch)
+    end = datetime.now()
+    return (end - start).total_seconds()
+
+
+def compare_encoders(encoders: dict[str, TextEncoder]):
+    test_sentences, batch_sentences = prep_dataset()
+    print(len(test_sentences))
+    output = {"single": {}}
+    for name, encoder in encoders.items():
+        single = benchmark_single(test_sentences, encoder)
+        print(f"[{name}] Single: total {single}s, avg {single/len(test_sentences)}s per item")
+        output["single"][name] = (single, single/len(test_sentences))
+
+    for batch_size, batched_list in batch_sentences.items():
+        output[batch_size] = {}
+        for name, encoder in encoders.items():
+            batch_time = benchmark_batch(batched_list, encoder)
+            output[batch_size][name] = (batch_time, batch_time/len(batched_list))
+            print(f"[{name}] {batch_size} batch: total {batch_time}s, avg {batch_time/len(batched_list)}s per item")
+    return output
+
+
+if __name__ == "__main__":
+    USE_encoder = universal_sentence_encoder.USETextEncoder()
+    USE_encoder.init()
+    output = compare_encoders({
+        "ada": openai_ada_encoder.ADATextEncoder("PLACE_HOLDER"), 
+        "use": USE_encoder
+    })
+    print(output)

--- a/benchmark-tests/requirements-no-deps.txt
+++ b/benchmark-tests/requirements-no-deps.txt
@@ -1,0 +1,4 @@
+# This is needed to resolve a bug with apache beam + datasets
+# Read https://github.com/huggingface/datasets/issues/5613 for more details
+multiprocess==0.70.11
+dill==0.3.6

--- a/benchmark-tests/requirements.txt
+++ b/benchmark-tests/requirements.txt
@@ -1,0 +1,7 @@
+ipykernel
+datasets==2.13.1
+apache_beam==2.49.0
+openai
+
+memas-sdk
+memas-client

--- a/benchmark-tests/setup-env.sh
+++ b/benchmark-tests/setup-env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+pip install -r requirements.txt
+# TODO: remove this after beam/datasets package upgrade 
+pip install --no-deps -r requirements-no-deps.txt

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -14,7 +14,7 @@ from memas.storage_driver import corpus_doc_store, corpus_vector_store
 # TODO: properly create different sets of configs and load them according to scenario
 
 corpus_doc_store.CORPUS_INDEX = "memas-integ-test"
-corpus_vector_store.USE_COLLECTION_NAME = "memas_USE_integ_test"
+corpus_vector_store.ENCODER_COLLECTION_NAME = "memas_{encoder}_integ_test"
 
 
 CONFIG_PATH = "../integration-tests/integ-test-config.yml"
@@ -33,7 +33,7 @@ def clean_resources():
 
     try:
         milvus_connection.connect("default", host=constants.milvus_ip, port=constants.milvus_port)
-        utility.drop_collection(collection_name=corpus_vector_store.USE_COLLECTION_NAME)
+        utility.drop_collection(collection_name=corpus_vector_store.ENCODER_COLLECTION_NAME.format(encoder="USE"))
         milvus_connection.disconnect("default")
     except Exception:
         pass

--- a/integration-tests/storage_driver/test_corpus_vector_store.py
+++ b/integration-tests/storage_driver/test_corpus_vector_store.py
@@ -1,10 +1,11 @@
 import numpy as np
 import uuid
 import time
+from memas.encoder.universal_sentence_encoder import USETextEncoder
 from memas.interface.storage_driver import DocumentEntity
-from memas.storage_driver.corpus_vector_store import MilvusUSESentenceVectorStore
+from memas.storage_driver.corpus_vector_store import MilvusSentenceVectorStore
 
-store = MilvusUSESentenceVectorStore()
+store = MilvusSentenceVectorStore(USETextEncoder())
 
 
 def test_init():

--- a/memas/context_manager.py
+++ b/memas/context_manager.py
@@ -7,6 +7,7 @@ from cassandra.cluster import Cluster, Session
 from cassandra.cqlengine import connection as c_connection
 from elasticsearch import Elasticsearch
 from pymilvus import connections as milvus_connection
+from memas.encoder.universal_sentence_encoder import USETextEncoder
 from memas.interface.exceptions import IllegalStateException
 from memas.interface.storage_driver import CorpusDocumentMetadataStore, CorpusDocumentStore, CorpusVectorStore, MemasMetadataStore
 from memas.storage_driver import corpus_doc_metadata, corpus_doc_store, corpus_vector_store, memas_metadata
@@ -64,7 +65,7 @@ class ContextManager:
         # Data Stores
         self.memas_metadata: MemasMetadataStore = memas_metadata.SINGLETON
         self.corpus_metadata: CorpusDocumentMetadataStore = corpus_doc_metadata.SINGLETON
-        self.corpus_vec: CorpusVectorStore = corpus_vector_store.SINGLETON
+        self.corpus_vec: CorpusVectorStore = corpus_vector_store.MilvusSentenceVectorStore(USETextEncoder())
         self.corpus_doc: CorpusDocumentStore
 
         # clients

--- a/memas/encoder/openai_ada_encoder.py
+++ b/memas/encoder/openai_ada_encoder.py
@@ -1,0 +1,22 @@
+import numpy as np
+import openai
+from memas.interface.encoder import TextEncoder
+
+
+ADA_MODEL="text-embedding-ada-002"
+
+
+class ADATextEncoder(TextEncoder):
+    def __init__(self, api_key) -> None:
+        super().__init__(ENCODER_NAME="ADA", VECTOR_DIMENSION=1536)
+        openai.api_key = api_key
+
+    def init(self):
+        pass
+
+    def embed(self, text: str) -> np.ndarray:
+        return np.array(openai.Embedding.create(input = [text], model=ADA_MODEL)['data'][0]['embedding'])
+
+    def embed_multiple(self, text_list: list[str]) -> list[np.ndarray]:
+        embeddings = openai.Embedding.create(input = text_list, model=ADA_MODEL)['data']
+        return [np.array(resp['embedding']) for resp in embeddings]

--- a/memas/encoder/universal_sentence_encoder.py
+++ b/memas/encoder/universal_sentence_encoder.py
@@ -15,14 +15,14 @@ USE_VECTOR_DIMENSION = 512
 
 class USETextEncoder(TextEncoder):
     def __init__(self, model_url: str = USE_LOCAL_MODEL_URL) -> None:
-        super().__init__()
+        super().__init__(ENCODER_NAME="USE", VECTOR_DIMENSION=USE_VECTOR_DIMENSION)
         self.model_url: str = model_url
 
     def init(self):
         self.encoder = hub.load(self.model_url)
 
     def embed(self, text: str) -> np.ndarray:
-        return self.encoder(text).numpy()
+        return self.encoder([text]).numpy()
 
     def embed_multiple(self, text_list: list[str]) -> list[np.ndarray]:
         return [x.numpy() for x in self.encoder(text_list)]

--- a/memas/interface/encoder.py
+++ b/memas/interface/encoder.py
@@ -3,6 +3,10 @@ import numpy
 
 
 class TextEncoder(ABC):
+    def __init__(self, ENCODER_NAME: str, VECTOR_DIMENSION: int) -> None:
+        self.ENCODER_NAME: str = ENCODER_NAME
+        self.VECTOR_DIMENSION: str = VECTOR_DIMENSION
+
     @abstractmethod
     def init(self):
         """Initialize the encoder

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ pymilvus==2.2.8
 elasticsearch==8.8.0
 scylla-driver==3.26.2
 nltk
+openai
 gunicorn[eventlet]
 futurist


### PR DESCRIPTION
Decouple vector store and encoders, also implementing openai ada support.

Will not pursue using ada yet, it is too much slower than USE due to network latency. Here's the results of my experiment, ran on 10 wikipedia pages.
```
Splitting 11 documents into 3121 sentences took 0.033806s
[ada] Single: total 504.94618s, avg 0.16178986863184877s per item
[use] Single: total 3.12516s, avg 0.0010013329061198334s per item
[ada] 5 batch: total 141.952905s, avg 0.2274886298076923s per item
[use] 5 batch: total 1.017821s, avg 0.0016311233974358975s per item
[ada] 10 batch: total 76.166642s, avg 0.24412385256410254s per item
[use] 10 batch: total 0.732307s, avg 0.0023471378205128205s per item
[ada] 20 batch: total 44.71862s, avg 0.2866578205128205s per item
[use] 20 batch: total 0.530946s, avg 0.0034035000000000003s per item
[ada] 50 batch: total 24.703333s, avg 0.39844085483870967s per item
[use] 50 batch: total 0.431493s, avg 0.006959564516129032s per item
[ada] 100 batch: total 19.059711s, avg 0.6148293870967741s per item
[use] 100 batch: total 0.397267s, avg 0.012815064516129031s per item
```