### PR TITLE
Implemented delete corpus using celery. Also made many refactors

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 # Port to run memas
 FLASK_RUN_PORT=8010
 
+MEMAS_CONF_FILE=memas-config.yml
 
 # Password for the 'elastic' user (at least 6 characters)
 ELASTIC_PASSWORD=abc123

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[FORMAT]
+max-line-length=120

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To stop docker execution, run Control+C in the terminal you are running `docker 
 
 If you want to clean your local docker images, run 
 ```bash
-docker compose down --volumes
+docker compose --profile dev down --volumes
 ```
 
 FYI you may need to run `sysctl -w vm.max_map_count=262144` if you get an error when trying to start elasticsearch.
@@ -46,20 +46,20 @@ docker compose up
 If this is your first time initializing the MeMaS server, after `docker compose up` and wait till the dependencies are fully started, run `source setup-env.sh`, then
 
 ```bash
-flask --app 'memas.app:create_app(config_filename="memas-config.yml", first_init=True)' run
+flask --app 'memas.app:create_app(first_init=True)' run
 ```
 
 This will run for a while then exit. Upon exit, your MeMaS is properly setup. **NOTE: Only run this phase when you are working with a clean set of docker dependencies, aka a fresh start or after `docker compose down --volumes`.**
 
 After MeMaS is properly initialized, run `source setup-env.sh`, then:
 ```bash
-flask --app 'memas.app:create_app(config_filename="memas-config.yml")' run
+flask --app 'memas.app:create_app' run
 ``` 
 to start the memas server.
 
 And to run the app with wsgi server, run
 ```bash
-gunicorn -w 1 -k eventlet 'memas.app:create_app(config_filename="memas-config.yml")'
+gunicorn -w 1 -k eventlet 'memas.app:create_app'
 ```
 note `-w` sets the number of worker threads. 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --chmod=0755 memas-docker/init.sh ./init.sh
 
 # Copy in the default config
 ARG conf_file=memas-config.yml
-ENV conf_file=${conf_file}
+ENV MEMAS_CONF_FILE=${conf_file}
 COPY memas-docker/${conf_file} ./memas/${conf_file}
 # TODO: provide way to use custom configs in docker compose
 
@@ -34,4 +34,4 @@ ENV PYTHONPATH "$PYTHONPATH:memas"
 
 
 EXPOSE 8010
-CMD gunicorn -b :8010 -w 1 -k eventlet "memas.app:create_app(config_filename=\"${conf_file}\")"
+CMD gunicorn -b :8010 -w 1 -k eventlet "memas.app:create_app()"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,29 @@ services:
     # command: ./wait-for-it.sh milvus-standalone:19530 -t 300 -- gunicorn -w 1 -k eventlet 'memas.app:create_app(config_filename="memas-config.yml")'
     profiles: ["dev"]
 
+  memas-worker:
+    build: 
+      context: .
+    image: memas:latest
+    container_name: memas-worker
+    depends_on: 
+      memas-init:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    volumes:
+      - memas_data:/memas
+    command: celery --app memas.make_celery worker --loglevel INFO
+    profiles: ["dev"]
+
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_data:/data
+
   scylla:
     image: scylladb/scylla
     container_name: scylla
@@ -63,6 +86,11 @@ services:
     volumes:
       - etcd_data:/etcd
     command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
 
   minio:
     container_name: milvus-minio
@@ -71,8 +99,8 @@ services:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
     volumes:
-      - minio_data:/data
-    command: minio server /data
+      - minio_data:/minio_data
+    command: minio server /minio_data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
@@ -81,7 +109,7 @@ services:
 
   milvus:
     container_name: milvus-standalone
-    image: milvusdb/milvus:v2.2.8
+    image: milvusdb/milvus:v2.3.2
     command: ["milvus", "run", "standalone"]
     environment:
       ETCD_ENDPOINTS: etcd:2379
@@ -115,6 +143,9 @@ services:
 
 volumes:
   memas_data:
+    driver: local
+
+  redis_data:
     driver: local
 
   esdata01:

--- a/integration-tests/corpus/test_basic_corpus.py
+++ b/integration-tests/corpus/test_basic_corpus.py
@@ -1,16 +1,17 @@
 import numpy as np
 import uuid
 import time
-from memas.context_manager import ctx
 from memas.corpus import basic_corpus
-from memas.interface.corpus import Citation
+from memas.interface.corpus import Citation, CorpusInfo, CorpusType
 
 corpus_name = "test corpus1"
 
 
-def test_save_then_search_one_corpus(es_client):
-    test_corpus = basic_corpus.BasicCorpus(
-        uuid.uuid4(), corpus_name, ctx.corpus_metadata, ctx.corpus_doc, ctx.corpus_vec)
+def test_save_then_search_one_corpus(ctx):
+    namespace_id = uuid.uuid4()
+    corpus_id = uuid.uuid4()
+    corpus_info = CorpusInfo("test_corpus_save_search", namespace_id, corpus_id, CorpusType.CONVERSATION)
+    test_corpus = basic_corpus.BasicCorpus(corpus_info, ctx.corpus_metadata, ctx.corpus_doc, ctx.corpus_vec)
 
     text1 = "The sun is high. California sunshine is great. "
     text2 = "I picked up my phone and then dropped it again. I cant seem to get a good grip on things these days. It persists into my everyday tasks"
@@ -26,3 +27,27 @@ def test_save_then_search_one_corpus(es_client):
     # print(output)
     assert "sunshine" in output[1][0]
     assert "weather" in output[0][0]
+
+
+def test_delete_all_content(ctx):
+    namespace_id = uuid.uuid4()
+    corpus_id = uuid.uuid4()
+    corpus_info = CorpusInfo("test_delete_all_content", namespace_id, corpus_id, CorpusType.CONVERSATION)
+    test_corpus = basic_corpus.BasicCorpus(corpus_info, ctx.corpus_metadata, ctx.corpus_doc, ctx.corpus_vec)
+
+    text1 = "The sun is high. California sunshine is great. "
+    text2 = "I picked up my phone and then dropped it again. I cant seem to get a good grip on things these days. It persists into my everyday tasks"
+    text3 = "The weather is great today, but I worry that tomorrow it won't be. My umbrella is in the repair shop."
+
+    assert test_corpus.store_and_index(text1, Citation("www.docsource1", "SSSdoc1", "", "doc1"))
+    assert test_corpus.store_and_index(text2, Citation("were.docsource2", "SSSdoc2", "", "doc2"))
+    assert test_corpus.store_and_index(text3, Citation("docsource3.ai", "SSSdoc3", "", "doc3"))
+
+    time.sleep(1)
+    output = test_corpus.search("It is sunny")
+    assert "sunshine" in output[1][0]
+
+    test_corpus.delete_all_content()
+    time.sleep(1)
+    output = test_corpus.search("It is sunny")
+    assert output == []

--- a/integration-tests/integ-test-config.yml
+++ b/integration-tests/integ-test-config.yml
@@ -11,3 +11,8 @@ ELASTICSEARCH:
 MILVUS:
   ip: "127.0.0.1"
   port: 19530
+
+CELERY:
+  broker_url: "redis://localhost"
+  result_backend: "redis://localhost"
+  task_ignore_result: True

--- a/integration-tests/storage_driver/test_corpus_doc_metadata.py
+++ b/integration-tests/storage_driver/test_corpus_doc_metadata.py
@@ -1,5 +1,7 @@
+import pytest
 import uuid
 from memas.interface.corpus import Citation
+from memas.interface.exceptions import DocumentMetadataNotFound
 from memas.storage_driver.corpus_doc_metadata import CorpusDocumentMetadataStoreImpl
 
 
@@ -17,3 +19,15 @@ def test_insert_and_get():
     citation = Citation("google.com", "test google", "just a simple test", "test")
     metadata.insert_document_metadata(corpus_id, document_id, 1, citation)
     assert metadata.get_document_citation(corpus_id, document_id) == citation
+
+
+def test_delete_corpus():
+    corpus_id = uuid.uuid4()
+    document_id = uuid.uuid4()
+
+    citation = Citation("google.com", "test google", "just a simple test", "test")
+    metadata.insert_document_metadata(corpus_id, document_id, 1, citation)
+    metadata.delete_corpus(corpus_id)
+
+    with pytest.raises(DocumentMetadataNotFound):
+        metadata.get_document_citation(corpus_id, document_id)

--- a/integration-tests/storage_driver/test_corpus_doc_store.py
+++ b/integration-tests/storage_driver/test_corpus_doc_store.py
@@ -7,13 +7,13 @@ import uuid
 import time
 
 
-def test_init(es_client: Elasticsearch):
-    doc_store = corpus_doc_store.ESDocumentStore(es_client)
+def test_init(ctx: ContextManager):
+    doc_store = corpus_doc_store.ESDocumentStore(ctx.es)
     doc_store.init()
 
 
-def test_save_then_search(es_client):
-    doc_store = corpus_doc_store.ESDocumentStore(es_client)
+def test_save_then_search(ctx: ContextManager):
+    doc_store = corpus_doc_store.ESDocumentStore(ctx.es)
     doc_store.init()
 
     corpus_id1 = uuid.uuid1()

--- a/integration-tests/storage_driver/test_corpus_vector_store.py
+++ b/integration-tests/storage_driver/test_corpus_vector_store.py
@@ -12,7 +12,7 @@ def test_init():
     store.init()
 
 
-def test_save_then_search2():
+def test_save_then_search():
     print("before UIDs")
     corpus_id1 = uuid.uuid4()
     corpus_id2 = uuid.uuid4()
@@ -46,3 +46,27 @@ def test_save_then_search2():
 
     # Test that the document stored in the other corpus isn't a result
     assert document_id3 not in {t[1].document_id for t in result}
+
+
+def test_delete_corpus():
+    corpus_id1 = uuid.uuid4()
+    document_id0 = uuid.uuid4()
+    document_id1 = uuid.uuid4()
+    document_id2 = uuid.uuid4()
+
+    best_match_str = "The sun is high. California sunshine is great. "
+
+    store.save_documents([DocumentEntity(corpus_id1, document_id0, "doc0",
+                                         "Before This is a runon sentence meant to test the logic of the splitting capabilites but that is only the start, there is nothing that can break this sentecne up other than some handy logic even in the worst case, too bad I only know how to use commas")])
+    store.save_documents([DocumentEntity(corpus_id1, document_id1, "doc1",
+                                         "The sun is high! California sunshine is great. Did you catch my quest? Oh oh! lol")])
+    store.save_documents([DocumentEntity(corpus_id1, document_id2, "doc2",
+                                         "I picked up my phone and then dropped it again")])
+    time.sleep(1)
+
+    store.delete_corpus(corpus_id1)
+    time.sleep(1)
+
+    result = store.search_corpora([corpus_id1], "How's the weather today?")
+
+    assert len(result) == 0

--- a/integration-tests/storage_driver/test_memas_metadata.py
+++ b/integration-tests/storage_driver/test_memas_metadata.py
@@ -1,6 +1,7 @@
 import pytest
-from memas.interface.corpus import CorpusType
-from memas.interface.exceptions import NamespaceExistsException
+import uuid
+from memas.interface.corpus import CorpusInfo, CorpusType
+from memas.interface.exceptions import IllegalStateException, NamespaceExistsException, NamespaceDoesNotExistException
 from memas.interface.namespace import ROOT_ID
 from memas.storage_driver.memas_metadata import MemasMetadataStoreImpl
 
@@ -56,4 +57,58 @@ def test_get_query_corpora():
     corpus_id2 = metadata.create_conversation_corpus("test_get_query_corpora:convo1")
 
     corpora = metadata.get_query_corpora("test_get_query_corpora")
-    assert corpora == {corpus_id1, corpus_id2}
+    assert corpora == {
+        CorpusInfo("test_get_query_corpora:knowledge1", namespace_id, corpus_id1, CorpusType.CONVERSATION),
+        CorpusInfo("test_get_query_corpora:convo1", namespace_id, corpus_id2, CorpusType.CONVERSATION)
+    }
+
+
+def test_initiate_delete_corpus():
+    metadata.init()
+
+    namespace_id = metadata.create_namespace("test_initiate_delete_corpus")
+    corpus_pathname = "test_initiate_delete_corpus:convo1"
+    corpus_id = metadata.create_conversation_corpus(corpus_pathname)
+
+    corpus_info = metadata.get_corpus_info(corpus_pathname)
+    assert corpus_info.corpus_id == corpus_id
+
+    metadata.initiate_delete_corpus(namespace_id, corpus_id, corpus_pathname)
+
+    # since it's not a full delete, we'll still be able to query metadata given the ids
+    corpus_info = metadata.get_corpus_info_by_id(namespace_id, corpus_id)
+    assert corpus_info.corpus_id == corpus_id
+
+    with pytest.raises(NamespaceDoesNotExistException):
+        corpus_info = metadata.get_corpus_info(corpus_pathname)
+
+
+def test_initiate_delete_wrong_corpus():
+    metadata.init()
+
+    namespace_id = metadata.create_namespace("initiate_delete_wrong_corpus")
+    corpus_pathname = "initiate_delete_wrong_corpus:convo1"
+    corpus_id = metadata.create_conversation_corpus(corpus_pathname)
+
+    corpus_info = metadata.get_corpus_info(corpus_pathname)
+    assert corpus_info.corpus_id == corpus_id
+
+    with pytest.raises(NamespaceDoesNotExistException):
+        metadata.initiate_delete_corpus(namespace_id, uuid.uuid4(), corpus_pathname)
+
+
+def test_finish_delete_corpus():
+    metadata.init()
+
+    namespace_id = metadata.create_namespace("test_finish_delete_corpus")
+    corpus_pathname = "test_finish_delete_corpus:convo1"
+    corpus_id = metadata.create_conversation_corpus(corpus_pathname)
+
+    corpus_info = metadata.get_corpus_info_by_id(namespace_id, corpus_id)
+    assert corpus_info.corpus_id == corpus_id
+
+    metadata.initiate_delete_corpus(namespace_id, corpus_id, corpus_pathname)
+    metadata.finish_delete_corpus(namespace_id, corpus_id)
+
+    with pytest.raises(IllegalStateException):
+        metadata.get_corpus_info_by_id(namespace_id, corpus_id)

--- a/integration-tests/test_celery_worker.py
+++ b/integration-tests/test_celery_worker.py
@@ -1,0 +1,15 @@
+import pytest
+from unittest import mock
+import memas.celery_worker
+from memas.interface.exceptions import NamespaceDoesNotExistException
+
+
+@mock.patch("memas.celery_worker.time.sleep")
+def test_delete_corpus(mock_sleep, ctx):
+    namespace_id = ctx.memas_metadata.create_namespace("celery_delete_corpus")
+    corpus_pathname = "celery_delete_corpus:corpus1"
+    corpus_id = ctx.memas_metadata.create_conversation_corpus(corpus_pathname)
+    memas.celery_worker.delete_corpus(namespace_id, corpus_id, corpus_pathname)
+
+    with pytest.raises(NamespaceDoesNotExistException):
+        ctx.memas_metadata.get_corpus_ids_by_name(corpus_pathname)

--- a/integration-tests/test_controlplane.py
+++ b/integration-tests/test_controlplane.py
@@ -1,3 +1,4 @@
+from unittest import mock
 
 
 def test_create_user(test_client):
@@ -22,3 +23,12 @@ def test_create_corpus_existing(test_client):
     resp = test_client.post("/cp/create_corpus", json={"corpus_pathname": "create_user_2:create_corpus_2"})
     assert resp.status_code == 400
     assert resp.json["error_code"] == "namespace_exists"
+
+
+@mock.patch("memas.celery_worker.delete_corpus")
+def test_delete_corpus(mock_delete_corpus, test_client):
+    test_client.post("/cp/create_corpus", json={"corpus_pathname": "create_user_2:delete_corpus"})
+
+    resp = test_client.post("/cp/delete_corpus", json={"corpus_pathname": "create_user_2:delete_corpus"})
+    assert resp.status_code == 200
+    assert mock_delete_corpus.has_called()

--- a/memas-docker/init.sh
+++ b/memas-docker/init.sh
@@ -25,5 +25,5 @@ if [ ! -e /memas/first-init.lock ]
 then
     # If initialization succeeded, create the lock file, and write our current version to it
     # FIXME: is running flask instead of gunicorn a security concern? Gunicorn keeps on trying to restart the worker thread despite we're intentionally exiting
-    flask --app "memas.app:create_app(config_filename=\"$conf_file\", first_init=True)" run && touch /memas/first-init.lock; echo $version > /memas/first-init.lock
+    flask --app "memas.app:create_app(first_init=True)" run && touch /memas/first-init.lock; echo $version > /memas/first-init.lock
 fi

--- a/memas-docker/memas-config.yml
+++ b/memas-docker/memas-config.yml
@@ -11,3 +11,8 @@ ELASTICSEARCH:
 MILVUS:
   ip: "milvus-standalone"
   port: 19530
+
+CELERY:
+  broker_url: "redis://redis"
+  result_backend: "redis://redis"
+  task_ignore_result: True

--- a/memas/app.py
+++ b/memas/app.py
@@ -1,19 +1,36 @@
+import sys
 import traceback
 import yaml
+from celery import Celery, Task
 from flask import Flask
-from memas.context_manager import ContextManager
+from memas.context_manager import read_env, ContextManager
 from memas.interface.exceptions import MemasException
 
 
-def create_app(config_filename, *, first_init=False):
+def celery_init_app(app: Flask) -> Celery:
+    class FlaskTask(Task):
+        def __call__(self, *args: object, **kwargs: object) -> object:
+            with app.app_context():
+                return self.run(*args, **kwargs)
+
+    celery_app = Celery(app.name, task_cls=FlaskTask)
+    celery_app.config_from_object(app.config["CELERY"])
+    celery_app.set_default()
+    app.extensions["celery"] = celery_app
+    return celery_app
+
+
+def create_app(*, config_filename=None, first_init=False):
     app = Flask(__name__)
 
+    if config_filename is None:
+        config_filename = read_env("MEMAS_CONF_FILE")
     app.config.from_file(config_filename, load=yaml.safe_load)
     app.ctx: ContextManager = ContextManager(app.config)
     if first_init:
         app.ctx.first_init()
         app.logger.info("Finished first time initialization")
-        exit(0)
+        sys.exit(0)
 
     app.ctx.init()
 
@@ -22,6 +39,8 @@ def create_app(config_filename, *, first_init=False):
         app.logger.info(f"{e.__class__.__name__}: {e.return_obj()}")
         # app.logger.info(traceback.format_exc())
         return e.return_obj(), e.status_code.value
+
+    celery_init_app(app)
 
     from memas.dataplane import dataplane
     from memas.controlplane import controlplane

--- a/memas/celery_worker.py
+++ b/memas/celery_worker.py
@@ -1,0 +1,40 @@
+import time
+from uuid import UUID
+from celery import shared_task
+from celery.utils.log import get_task_logger
+from memas.context_manager import ctx
+from memas.interface.exceptions import NamespaceDoesNotExistException
+
+
+logger = get_task_logger(__name__)
+
+
+@shared_task(ignore_result=True)
+def delete_corpus(parent_id: UUID, corpus_id: UUID, corpus_pathname: str):
+    logger.info(
+        f"celery delete corpus for [corpus_pathname={corpus_pathname}] [parent_id={parent_id}] [corpus_id={corpus_id}]")
+
+    # Sleep for x seconds to avoid a race condition with the flask's delete_corpus handler
+    time.sleep(3)
+    corpus_exists = True
+
+    try:
+        # It is expected the namespace doesn't exist, since the original delete_corpus api should have deleted it.
+        corpus_info = ctx.memas_metadata.get_corpus_info(corpus_pathname)
+    except NamespaceDoesNotExistException:
+        logger.debug(f"initiate_delete_corpus was successful originally")
+        corpus_info = ctx.memas_metadata.get_corpus_info_by_id(parent_id, corpus_id)
+        corpus_exists = False
+
+    # When the get_corpus_ids_by_name doesn't fail, initiate the delete again, in case the delete earlier was interrupted
+    if corpus_exists:
+        ctx.memas_metadata.initiate_delete_corpus(parent_id, corpus_id, corpus_pathname)
+        logger.warning(
+            f"Corpus deletion failed but recovered [corpus_id={corpus_id}] [corpus_pathname={corpus_pathname}]")
+
+    # Then delete the content within the corpus
+    corpus = ctx.corpus_provider.get_corpus_by_info(corpus_info)
+    corpus.delete_all_content()
+
+    # finally delete the metadata
+    ctx.memas_metadata.finish_delete_corpus(parent_id, corpus_id)

--- a/memas/context_manager.py
+++ b/memas/context_manager.py
@@ -122,7 +122,8 @@ class ContextManager:
         self.corpus_vec.init()
         self.corpus_doc.init()
 
-        self.corpus_provider = CorpusProvider(self.corpus_metadata, self.corpus_doc, self.corpus_vec)
+        self.corpus_provider = CorpusProvider(
+            self.memas_metadata, self.corpus_metadata, self.corpus_doc, self.corpus_vec)
 
     def init(self) -> None:
         self.init_clients()

--- a/memas/corpus/basic_corpus.py
+++ b/memas/corpus/basic_corpus.py
@@ -1,7 +1,7 @@
 # from search_redirect import SearchSettings
 import logging
 import uuid
-from memas.interface.corpus import Corpus, CorpusFactory
+from memas.interface.corpus import Corpus, CorpusInfo, CorpusFactory
 from memas.interface.corpus import Citation
 from memas.interface.storage_driver import CorpusDocumentMetadataStore, CorpusDocumentStore, CorpusVectorStore, DocumentEntity
 from memas.interface.exceptions import SentenceLengthOverflowException
@@ -15,8 +15,8 @@ _log = logging.getLogger(__name__)
 
 class BasicCorpus(Corpus):
 
-    def __init__(self, corpus_id: uuid.UUID, corpus_name: str, metadata_store: CorpusDocumentMetadataStore, doc_store: CorpusDocumentStore, vec_store: CorpusVectorStore):
-        super().__init__(corpus_id, corpus_name)
+    def __init__(self, corpus_info: CorpusInfo, metadata_store: CorpusDocumentMetadataStore, doc_store: CorpusDocumentStore, vec_store: CorpusVectorStore):
+        super().__init__(corpus_info)
         self.metadata_store: CorpusDocumentMetadataStore = metadata_store
         self.doc_store: CorpusDocumentStore = doc_store
         self.vec_store: CorpusVectorStore = vec_store
@@ -101,6 +101,12 @@ class BasicCorpus(Corpus):
 
         return results
 
+    def delete_all_content(self):
+        # TODO: parallelize
+        self.metadata_store.delete_corpus(self.corpus_id)
+        self.doc_store.delete_corpus(self.corpus_id)
+        self.vec_store.delete_corpus(self.corpus_id)
+
 
 class BasicCorpusFactory(CorpusFactory):
     def __init__(self, metadata_store: CorpusDocumentMetadataStore, doc_store: CorpusDocumentStore, vec_store: CorpusVectorStore) -> None:
@@ -109,6 +115,5 @@ class BasicCorpusFactory(CorpusFactory):
         self.doc_store: CorpusDocumentStore = doc_store
         self.vec_store: CorpusVectorStore = vec_store
 
-    def produce(self, corpus_id: uuid.UUID):
-        # TODO: Maybe change the Corpus Name Parameter
-        return BasicCorpus(corpus_id, "BasicCorpus", self.metadata_store, self.doc_store, self.vec_store)
+    def produce(self, corpus_info: CorpusInfo):
+        return BasicCorpus(corpus_info, self.metadata_store, self.doc_store, self.vec_store)

--- a/memas/corpus/corpus_provider.py
+++ b/memas/corpus/corpus_provider.py
@@ -1,31 +1,46 @@
 import logging
-from uuid import UUID
 from memas.corpus.basic_corpus import BasicCorpusFactory
-from memas.interface.corpus import Corpus, CorpusFactory, CorpusType
-from memas.interface.storage_driver import CorpusDocumentMetadataStore, CorpusDocumentStore, CorpusVectorStore
+from memas.interface.corpus import Corpus, CorpusFactory, CorpusInfo, CorpusType
+from memas.interface.storage_driver import CorpusDocumentMetadataStore, CorpusDocumentStore, CorpusVectorStore, MemasMetadataStore
 
 
 _log = logging.getLogger(__name__)
 
 
 class CorpusProvider:
-    def __init__(self, metadata_store: CorpusDocumentMetadataStore, doc_store: CorpusDocumentStore, vec_store: CorpusVectorStore) -> None:
+    def __init__(self,
+                 memas_metadata_store: MemasMetadataStore,
+                 doc_metadata_store: CorpusDocumentMetadataStore,
+                 doc_store: CorpusDocumentStore,
+                 vec_store: CorpusVectorStore
+                 ) -> None:
+        self.memas_metadata_store: MemasMetadataStore = memas_metadata_store
+
         self.factory_dict: dict[CorpusType, CorpusFactory] = dict()
 
-        basic_corpus_factory = BasicCorpusFactory(metadata_store, doc_store, vec_store)
+        basic_corpus_factory = BasicCorpusFactory(doc_metadata_store, doc_store, vec_store)
         self.factory_dict[CorpusType.CONVERSATION] = basic_corpus_factory
         self.factory_dict[CorpusType.KNOWLEDGE] = basic_corpus_factory
 
-    def get_corpus(self, corpus_id: UUID, *, corpus_type: CorpusType, namespace_id: UUID = None) -> Corpus:
-        """Gets the Corpus class based on the corpus_id
+    def get_corpus_by_name(self, corpus_pathname: str) -> Corpus:
+        """Gets the Corpus class based on the corpus_pathname
 
         Args:
-            corpus_id (UUID): corpus_id
-            corpus_type (CorpusType): type of the corpus, this is necessary unless a namespace_id is provided
-            namespace_id (UUID): namespace_id of the corpus, this is necessary when a corpus type is not provided, 
-                since it's needed to find the corpus type.
+            corpus_pathname (str): corpus pathname
 
         Returns:
-            Corpus: _description_
+            Corpus: Corpus object for searching
         """
-        return self.factory_dict[corpus_type].produce(corpus_id)
+        corpus_info = self.memas_metadata_store.get_corpus_info(corpus_pathname)
+        return self.get_corpus_by_info(corpus_info)
+
+    def get_corpus_by_info(self, corpus_info: CorpusInfo) -> Corpus:
+        """Gets the Corpus class based on the CorpusInfo
+
+        Args:
+            corpus_info (CorpusInfo): corpus info object
+
+        Returns:
+            Corpus: Corpus object for searching
+        """
+        return self.factory_dict[corpus_info.corpus_type].produce(corpus_info)

--- a/memas/dataplane.py
+++ b/memas/dataplane.py
@@ -14,13 +14,12 @@ def recall():
 
     current_app.logger.info(f"Recalling [namespace_pathname=\"{namespace_pathname}\"]")
 
-    corpus_ids = ctx.memas_metadata.get_query_corpora(namespace_pathname)
+    corpus_infos = ctx.memas_metadata.get_query_corpora(namespace_pathname)
 
-    current_app.logger.debug(f"Querying corpuses: {corpus_ids}")
+    current_app.logger.debug(f"Querying corpuses: {corpus_infos}")
     search_results: list[tuple[str, Citation]] = []
-    for corpus_id in corpus_ids:
-        # TODO: either provide corpus_type or namespace_pathname
-        corpus: Corpus = ctx.corpus_provider.get_corpus(corpus_id, corpus_type=CorpusType.KNOWLEDGE)
+    for corpus_info in corpus_infos:
+        corpus: Corpus = ctx.corpus_provider.get_corpus_by_info(corpus_info)
         search_results.extend(corpus.search(clue=clue))
 
     # Combine the results and only take the top ones
@@ -47,9 +46,7 @@ def memorize():
                         description=raw_citation.get("description", ""),
                         document_name=document_name)
 
-    corpus_info = ctx.memas_metadata.get_corpus_info(corpus_pathname)
-
-    corpus: Corpus = ctx.corpus_provider.get_corpus(corpus_info.corpus_id, corpus_type=corpus_info.corpus_type)
+    corpus: Corpus = ctx.corpus_provider.get_corpus_by_name(corpus_pathname)
     success = corpus.store_and_index(document, citation)
 
     current_app.logger.info(f"Memorize finished [success={success}]")

--- a/memas/encoder/openai_ada_encoder.py
+++ b/memas/encoder/openai_ada_encoder.py
@@ -3,7 +3,7 @@ import openai
 from memas.interface.encoder import TextEncoder
 
 
-ADA_MODEL="text-embedding-ada-002"
+ADA_MODEL = "text-embedding-ada-002"
 
 
 class ADATextEncoder(TextEncoder):
@@ -15,8 +15,8 @@ class ADATextEncoder(TextEncoder):
         pass
 
     def embed(self, text: str) -> np.ndarray:
-        return np.array(openai.Embedding.create(input = [text], model=ADA_MODEL)['data'][0]['embedding'])
+        return np.array(openai.Embedding.create(input=[text], model=ADA_MODEL)['data'][0]['embedding'])
 
     def embed_multiple(self, text_list: list[str]) -> list[np.ndarray]:
-        embeddings = openai.Embedding.create(input = text_list, model=ADA_MODEL)['data']
+        embeddings = openai.Embedding.create(input=text_list, model=ADA_MODEL)['data']
         return [np.array(resp['embedding']) for resp in embeddings]

--- a/memas/interface/corpus.py
+++ b/memas/interface/corpus.py
@@ -20,18 +20,22 @@ class Citation:
 @dataclass
 class CorpusInfo:
     corpus_pathname: str
+    namespace_id: UUID
     corpus_id: UUID
     corpus_type: CorpusType
+
+    def __hash__(self) -> int:
+        return hash((self.namespace_id, self.corpus_id, self.corpus_pathname))
 
 
 class Corpus(ABC):
     """
-    Corpus interface used to hide the different implementations
+    Corpus interface used to access data within the corpus, and hide the different implementations
     """
 
-    def __init__(self, corpus_id: UUID, corpus_name: str):
-        self.corpus_id: UUID = corpus_id
-        self.corpus_name: str = corpus_name
+    def __init__(self, corpus_info: CorpusInfo):
+        self.corpus_id: UUID = corpus_info.corpus_id
+        self.corpus_info: CorpusInfo = corpus_info
 
     @abstractmethod
     def store_and_index(self, document: str, citation: Citation) -> bool:
@@ -56,9 +60,14 @@ class Corpus(ABC):
             list[tuple[str, Citation]]: a list of (document, citation) pairs
         """
 
+    @abstractmethod
+    def delete_all_content(self):
+        """Deletes all data in the corpus
+        """
+
 
 class CorpusFactory(ABC):
     @abstractmethod
-    def produce(self, corpus_id: UUID):
+    def produce(self, corpus_info: CorpusInfo):
         # FIXME: do we want to pass in any arguments?
         pass

--- a/memas/interface/exceptions.py
+++ b/memas/interface/exceptions.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from uuid import UUID
 
 
 class MemasInternalException(Exception):
@@ -29,6 +30,7 @@ class ErrorCode(Enum):
     NamespaceExists = "namespace_exists"
     NamespaceDoesNotExist = "namespace_does_not_exist"
     NamespaceIllegalName = "namespace_illegal_name"
+    NamespaceDeleting = "namespace_deleting"
 
 
 class MemasException(Exception):
@@ -65,4 +67,9 @@ class NamespaceDoesNotExistException(MemasException):
 # TODO: properly specify this exception type
 class SentenceLengthOverflowException(Exception):
     def __init__(self, sentence_len: int) -> None:
-        super().__init__("Sentence length is {len} which exceededs limit".format(len=sentence_len))
+        super().__init__(f"Sentence length is {sentence_len} which exceededs limit")
+
+
+class DocumentMetadataNotFound(IllegalStateException):
+    def __init__(self, corpus_id: UUID, document_id: UUID) -> None:
+        super().__init__(f"Document metadata not found for [corpus_id={corpus_id}] [document_id={document_id}]")

--- a/memas/make_celery.py
+++ b/memas/make_celery.py
@@ -1,0 +1,5 @@
+from app import create_app
+
+# This is the necessary entry point for initiating the celery worker
+flask_app = create_app()
+celery_app = flask_app.extensions["celery"]

--- a/memas/memas-config.yml
+++ b/memas/memas-config.yml
@@ -11,3 +11,8 @@ ELASTICSEARCH:
 MILVUS:
   ip: "127.0.0.1"
   port: 19530
+
+CELERY:
+  broker_url: "redis://localhost"
+  result_backend: "redis://localhost"
+  task_ignore_result: True

--- a/memas/storage_driver/corpus_doc_store.py
+++ b/memas/storage_driver/corpus_doc_store.py
@@ -93,3 +93,18 @@ class ESDocumentStore(CorpusDocumentStore):
                 hit["_id"][:32]), document_name=data[NAME_FIELD], document=data[DOC_FIELD])))
 
         return result
+
+    def delete_corpus(self, corpus_id: UUID):
+        _log.debug(f"Deleting documents for [corpus_id={corpus_id}]")
+        delete_query = {
+            "bool": {
+                "filter": [
+                    {"term":  {CORPUS_FIELD: corpus_id.hex}}
+                ]
+            }
+        }
+        response = self.es.delete_by_query(index=self.es_index, query=delete_query)
+        # TODO: add retry/error handling
+        assert not response["timed_out"]
+        _log.debug(
+            f"Corpus Metadata Deletion took {response['took']}ms, total {response['total']} entries, deleted {response['deleted']} entries.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 flask==2.3.2
+celery[redis]
 tensorflow==2.12.0
 tensorflow_hub
-pymilvus==2.2.8
+pymilvus==2.3.2
 elasticsearch==8.8.0
 scylla-driver==3.26.2
 nltk

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 pytest
 pylint
-autopep8
+autopep8>=2.0.4

--- a/tests/interface/test_corpus.py
+++ b/tests/interface/test_corpus.py
@@ -1,0 +1,13 @@
+import uuid
+from memas.interface.corpus import CorpusInfo, CorpusType
+
+
+def test_corpus_info_hashable():
+    namespace_id1 = uuid.uuid4()
+    corpus_id1 = uuid.uuid4()
+    corpus_info1 = CorpusInfo("test1", namespace_id1, corpus_id1, CorpusType.CONVERSATION)
+
+    try:
+        s = {corpus_info1}
+    except TypeError:
+        assert False, "CorpusInfo is not hashable"

--- a/tests/interface/test_namespace.py
+++ b/tests/interface/test_namespace.py
@@ -1,26 +1,54 @@
 import pytest
-from memas.interface.namespace import is_pathname_format_valid, is_name_format_valid
+from memas.interface.namespace import is_namespace_pathname_valid, is_corpus_pathname_valid, is_name_format_valid, mangle_corpus_pathname
+
+
+@pytest.mark.parametrize("parent_pathname, corpus_name, expected_pathname", [
+    ("aaa.bbb", "ccc", "aaa.bbb:ccc"),
+])
+def test_mangle_corpus_pathname(parent_pathname, corpus_name, expected_pathname):
+    assert mangle_corpus_pathname(parent_pathname, corpus_name) == expected_pathname
 
 
 @pytest.mark.parametrize("pathname", [
     "aaa.bbb.ccc",  # most standard namespace
-    "a.bb:ccc",  # most standard corpus
-    ":corpus",  # root level corpus
     "",  # The empty string namespace is the reserved root namespace
     "c",  # Single character names are allowed
     "AFD.my.namespace"  # capital case is allowed
 ])
-def test_pathname_format_valid(pathname):
-    assert is_pathname_format_valid(pathname)
+def test_namespace_pathname_format_valid(pathname):
+    assert is_namespace_pathname_valid(pathname)
+
+
+@pytest.mark.parametrize("pathname", [
+    "a.bb:ccc",  # most standard corpus
+    ":corpus",  # root level corpus
+])
+def test_corpus_pathname_format_valid(pathname):
+    assert is_corpus_pathname_valid(pathname)
 
 
 @pytest.mark.parametrize("pathname", [
     "x y",  # No spaces allowed
     "this,is\"also;bad",  # no weird separators
     "a..b",  # only the root namespace can be empty
+    "a.bb:ccc",  # most standard corpus
+    ":corpus",  # root level corpus
 ])
-def test_pathname_format_invalid(pathname):
-    assert not is_pathname_format_valid(pathname)
+def test_namespace_pathname_format_invalid(pathname):
+    assert not is_namespace_pathname_valid(pathname)
+
+
+@pytest.mark.parametrize("pathname", [
+    "x y",  # No spaces allowed
+    "this,is\"also;bad",  # no weird separators
+    "a..b",  # only the root namespace can be empty
+    "aaa.bbb.ccc",  # most standard namespace
+    "",  # The empty string namespace is the reserved root namespace
+    "c",  # Single character names are allowed
+    "AFD.my.namespace"  # capital case is allowed
+])
+def test_corpus_pathname_format_invalid(pathname):
+    assert not is_corpus_pathname_valid(pathname)
 
 
 @pytest.mark.parametrize("name", [


### PR DESCRIPTION
Implemented delete corpus using celery, a task queue worker using redis. 

The delete_corpus api first sends a task to celery, and then initiates the delete, by deleting the NamespaceNameToId entry. From the user perspective, while all the actual data remains, this effectively deletes the corpus, since the user no longer has any means to access the corpus. The celery worker then picks up the deletion, making sure the NamespaceNameToId is deleted, and then deletes all the data within the corpus.

Also made many minor refactors, such as to the get query corpus function.